### PR TITLE
libcameraservice: Add support to set vendor tag with client package name

### DIFF
--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -124,6 +124,9 @@ cc_library {
         "camera_package_name_defaults",
         "camera_needs_client_info_lib_defaults",
         "camera_needs_client_info_lib_oplus_defaults",
+        "uses_oplus_camera_defaults",
+        "uses_nothing_camera_defaults",
+
     ],
     // Camera service source
 

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -2431,7 +2431,7 @@ Status CameraService::connectHelper(const sp<CALLBACK>& cameraCb, const std::str
             "Camera API version %d", packagePid, clientPackageName.c_str(), cameraId.c_str(),
             static_cast<int>(effectiveApiLevel));
 
-    sCurrPackageName = clientPackageName.c_str();
+    sCurrPackageName = clientPackageName;
 
     nsecs_t openTimeNs = systemTime();
 

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -59,6 +59,13 @@
 #define ALOGVV(...) ((void)0)
 #endif
 
+#ifdef USES_OPLUS_CAMERA
+#define TAG_NAME "com.oplus.packageName"
+#endif
+#ifdef USES_NOTHING_CAMERA
+#define TAG_NAME "com.nothing.device.package_name"
+#endif
+
 // Convenience macro for transient errors
 #define CLOGE(fmt, ...) ALOGE("Camera %s: %s: " fmt, mId.c_str(), __FUNCTION__, \
             ##__VA_ARGS__)
@@ -2465,7 +2472,7 @@ status_t Camera3Device::configureStreamsLocked(int operatingMode,
         return BAD_VALUE;
     }
 
-#ifdef CAMERA_PACKAGE_NAME
+#ifdef TAG_NAME
     sp<VendorTagDescriptor> vTags;
     sp<VendorTagDescriptorCache> vCache = VendorTagDescriptorCache::getGlobalVendorTagCache();
     if (vCache.get()) {
@@ -2474,8 +2481,8 @@ status_t Camera3Device::configureStreamsLocked(int operatingMode,
         sessionParams.unlock(metaBuffer);
         vCache->getVendorTagDescriptor(vendorId, &vTags);
         uint32_t tag;
-        if (CameraMetadata::getTagFromName(CAMERA_PACKAGE_NAME, vTags.get(), &tag)) {
-            ALOGE("%s: Unable to get %s tag", __FUNCTION__, CAMERA_PACKAGE_NAME);
+        if (CameraMetadata::getTagFromName(TAG_NAME, vTags.get(), &tag)) {
+            ALOGE("%s: Unable to get %s tag", __FUNCTION__, TAG_NAME);
         } else {
             std::string pkgName = CameraService::getCurrPackageName();
             status_t res = const_cast<CameraMetadata&>(sessionParams).update(tag, String8(pkgName.c_str()));


### PR DESCRIPTION
* OEMs like OnePlus and Nothing detect camera package name to unlock features like 48mp.